### PR TITLE
Transition message handling to a formal state machine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ endif
 CFLAGS += -DLOCALEDIR=\"$(LOCALEDIR)\"
 
 PURPLE_COMPAT_FILES :=
-PURPLE_C_FILES := comms.c contacts.c direct.c groups.c message.c link.c libsignald.c $(C_FILES)
+PURPLE_C_FILES := comms.c contacts.c direct.c groups.c message.c link.c libsignald.c state.c $(C_FILES)
 
 .PHONY:	all FAILNOPURPLE clean install
 

--- a/libsignald.c
+++ b/libsignald.c
@@ -242,8 +242,6 @@ signald_signald_start(PurpleAccount *account)
 void
 signald_login(PurpleAccount *account)
 {
-    signald_init_state_machine();
-
     purple_debug_info(SIGNALD_PLUGIN_ID, "login\n");
 
     PurpleConnection *pc = purple_account_get_connection(account);
@@ -257,6 +255,8 @@ signald_login(PurpleAccount *account)
     purple_connection_set_flags(pc, pc_flags);
 
     SignaldAccount *sa = g_new0(SignaldAccount, 1);
+
+    signald_init_state_machine(sa);
 
     purple_connection_set_protocol_data(pc, sa);
 

--- a/libsignald.c
+++ b/libsignald.c
@@ -116,6 +116,9 @@ signald_handle_input(SignaldAccount *sa, const char * json)
             purple_notify_warning (NULL, SIGNALD_DIALOG_TITLE, SIGNALD_DIALOG_LINK, text);
             g_free (text);
 
+        } else if (purple_strequal(type, "unexpected_error")) {
+            purple_connection_error(sa->pc, PURPLE_CONNECTION_ERROR_OTHER_ERROR, _("signald reported an unexpected error. View the console output in debug mode for more information."));
+
         } else {
             purple_debug_error(SIGNALD_PLUGIN_ID, "Ignored message of unknown type '%s'.\n", type);
         }

--- a/libsignald.h
+++ b/libsignald.h
@@ -78,6 +78,7 @@ typedef struct {
 typedef gboolean (*SignaldTransitionCb)(SignaldAccount *, JsonObject *obj);
 
 typedef struct {
+    SignaldTransitionCb filter;
     SignaldTransitionCb handler;
     SignaldTransitionCb next_message;
 
@@ -86,6 +87,9 @@ typedef struct {
 
 void
 signald_subscribe (SignaldAccount *sa);
+
+int
+signald_strequalprefix (const char *s1, const char *s2);
 
 #include "state.h"
 #include "message.h"

--- a/libsignald.h
+++ b/libsignald.h
@@ -56,6 +56,12 @@
 #define SIGNALD_ACCOUNT_OPT_EXT_ATTACHMENTS_URL "external-attachments-url"
 
 typedef struct {
+    char *name;
+
+    GHashTable *transitions;
+} SignaldState;
+
+typedef struct {
     PurpleAccount *account;
     PurpleConnection *pc;
 
@@ -63,10 +69,20 @@ typedef struct {
 
     int fd;
     guint watcher;
+    SignaldState *current;
 
     // Maps signal group IDs to libpurple PurpleConversation objects that represent those chats.
     GHashTable *groups;
 } SignaldAccount;
+
+typedef gboolean (*SignaldTransitionCb)(SignaldAccount *, JsonObject *obj);
+
+typedef struct {
+    SignaldTransitionCb handler;
+    SignaldTransitionCb next_message;
+
+    SignaldState *next;
+} SignaldStateTransition;
 
 void
 signald_subscribe (SignaldAccount *sa);

--- a/libsignald.h
+++ b/libsignald.h
@@ -72,6 +72,7 @@ typedef struct {
 void
 signald_subscribe (SignaldAccount *sa);
 
+#include "state.h"
 #include "message.h"
 #include "direct.h"
 #include "groups.h"

--- a/libsignald.h
+++ b/libsignald.h
@@ -59,7 +59,6 @@ typedef struct {
     PurpleAccount *account;
     PurpleConnection *pc;
 
-    gboolean initialized;
     gboolean legacy_protocol;
 
     int fd;

--- a/state.c
+++ b/state.c
@@ -253,6 +253,8 @@ signald_handle_unexpected_link_error(SignaldAccount *sa, JsonObject *obj)
 gboolean
 signald_handle_unexpected_error(SignaldAccount *sa, JsonObject *obj)
 {
+    purple_connection_error(sa->pc, PURPLE_CONNECTION_ERROR_OTHER_ERROR, _("signald reported an unexpected error. View the console output in debug mode for more information."));
+
     return TRUE;
 }
 
@@ -335,7 +337,7 @@ signald_init_state_machine(SignaldAccount *sa)
     signald_add_transition(running, "group_updated", running, signald_get_groups, NULL, NULL);
     signald_add_transition(running, "group_list", running, signald_received_group_list, NULL, NULL);
     signald_add_transition(running, "account_list", running, signald_received_account_list, NULL, NULL);
-    signald_add_transition(running, "unexpected_error", running, NULL, signald_handle_unexpected_error, NULL);
+    signald_add_transition(running, "unexpected_error", running, signald_handle_unexpected_error, NULL, NULL);
 
     // TODO: mark message as delayed (maybe do not echo) until success is reported
     signald_add_transition(running, "success", running, NULL, NULL, NULL);

--- a/state.c
+++ b/state.c
@@ -320,19 +320,21 @@ signald_handle_message(SignaldAccount *sa, JsonObject *obj)
         return FALSE;
     }
 
-    purple_debug_info(SIGNALD_PLUGIN_ID,
-                      "Transitioned from '%s' to '%s'\n", 
-                      current->name,
-                      transition->next->name);
-
     if ((transition->next_message != NULL) && ! transition->next_message(sa, obj)) {
         return FALSE;
     }
 
-    current = transition->next;
+    if (transition->next != NULL) {
+        purple_debug_info(SIGNALD_PLUGIN_ID,
+                          "Transitioned from '%s' to '%s'\n", 
+                          current->name,
+                          transition->next->name);
 
-    if (current == NULL) {
+        current = transition->next;
+    } else {
         purple_debug_info(SIGNALD_PLUGIN_ID, "Reached terminal state in state machine.\n");
+
+        current = NULL;
     }
 
     return TRUE;

--- a/state.c
+++ b/state.c
@@ -250,14 +250,6 @@ signald_handle_unexpected_link_error(SignaldAccount *sa, JsonObject *obj)
     return TRUE;
 }
 
-gboolean
-signald_handle_unexpected_error(SignaldAccount *sa, JsonObject *obj)
-{
-    purple_connection_error(sa->pc, PURPLE_CONNECTION_ERROR_OTHER_ERROR, _("signald reported an unexpected error. View the console output in debug mode for more information."));
-
-    return TRUE;
-}
-
 void
 signald_init_state_machine(SignaldAccount *sa)
 {
@@ -337,7 +329,6 @@ signald_init_state_machine(SignaldAccount *sa)
     signald_add_transition(running, "group_updated", running, signald_get_groups, NULL, NULL);
     signald_add_transition(running, "group_list", running, signald_received_group_list, NULL, NULL);
     signald_add_transition(running, "account_list", running, signald_received_account_list, NULL, NULL);
-    signald_add_transition(running, "unexpected_error", running, signald_handle_unexpected_error, NULL, NULL);
 
     // TODO: mark message as delayed (maybe do not echo) until success is reported
     signald_add_transition(running, "success", running, NULL, NULL, NULL);

--- a/state.c
+++ b/state.c
@@ -1,0 +1,337 @@
+#include <gmodule.h>
+#include "libsignald.h"
+
+SignaldState *entrypoint = NULL;
+SignaldState *current = NULL;
+
+void
+signald_add_transition(SignaldState *prev, char *received, SignaldState *state, SignaldTransitionCb handler, SignaldTransitionCb next)
+{
+    SignaldStateTransition *transition = g_new0(SignaldStateTransition, 1);
+
+    transition->handler = handler;
+    transition->next_message = next;
+    transition->next = state;
+
+    g_hash_table_insert(prev->transitions, received, transition);
+}
+
+SignaldState *
+signald_new_state(SignaldState *prev, char *name, char *received, SignaldTransitionCb handler, SignaldTransitionCb next)
+{
+    SignaldState *state = g_new0(SignaldState, 1);
+
+    state->name = name;
+    state->transitions = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
+
+    if (prev != NULL) {
+        signald_add_transition(prev, received, state, handler, next);
+    }
+
+    return state;
+}
+
+gboolean
+signald_received_version(SignaldAccount *sa, JsonObject *obj)
+{
+    obj = json_object_get_object_member(obj, "data");
+    purple_debug_info(SIGNALD_PLUGIN_ID, "signald version: %s\n", json_object_get_string_member(obj, "version"));
+
+    return TRUE;
+}
+
+gboolean
+signald_check_proto_version(SignaldAccount *sa, JsonObject *obj)
+{
+    //
+    // This is a bit of a hack!  We want to detect if we're dealing with a
+    // new version of signald with the new protocol, or the old version.
+    //
+    // To test, we call get_user on the user account, using the new
+    // JsonAddress form of the call.  If it succeeds, we're dealing with
+    // a new signald.  If it fails, it's the old one.
+    //
+
+    const gchar *username = purple_account_get_username(sa->account);
+    JsonObject *address = json_object_new();
+
+    json_object_set_string_member(address, "number", username);
+
+    JsonObject *data = json_object_new();
+
+    json_object_set_string_member(data, "type", "get_user");
+    json_object_set_string_member(data, "username", username);
+    json_object_set_object_member(data, "recipientAddress", address);
+
+    if (!signald_send_json (sa, data)) {
+        //purple_connection_set_state(pc, PURPLE_DISCONNECTED);
+        purple_connection_error (sa->pc, PURPLE_CONNECTION_ERROR_NETWORK_ERROR, _("Could not write subscription message."));
+
+        json_object_unref(data);
+        return FALSE;
+    }
+
+    json_object_unref(data);
+
+    return TRUE;
+}
+
+gboolean
+signald_subscribed(SignaldAccount *sa, JsonObject *obj)
+{
+    purple_connection_set_state(sa->pc, PURPLE_CONNECTION_CONNECTED);
+
+    return TRUE;
+}
+
+gboolean
+signald_initialize_contacts(SignaldAccount *sa, JsonObject *obj)
+{
+    JsonObject *data = json_object_new();
+
+    json_object_set_string_member(data, "type", "list_contacts");
+    json_object_set_string_member(data, "username", purple_account_get_username(sa->account));
+
+    if (!signald_send_json (sa, data)) {
+        purple_connection_error (sa->pc, PURPLE_CONNECTION_ERROR_NETWORK_ERROR, _("Could not write subscription message."));
+    }
+
+    json_object_unref(data);
+
+    signald_assume_all_buddies_online(sa);
+
+    return TRUE;
+}
+
+gboolean
+signald_linking_uri(SignaldAccount *sa, JsonObject *obj)
+{
+    signald_parse_linking_uri(sa, obj);
+
+    return TRUE;
+}
+
+gboolean
+signald_linking_successful(SignaldAccount *sa, JsonObject *obj)
+{
+    signald_parse_linking_successful();
+
+    return TRUE;
+}
+
+gboolean
+signald_subscribe_after_link(SignaldAccount *sa, JsonObject *obj)
+{
+    signald_subscribe(sa);
+
+    return TRUE;
+}
+
+gboolean
+signald_linking_error(SignaldAccount *sa, JsonObject *obj)
+{
+    signald_parse_linking_error(sa, obj);
+
+    purple_notify_close_with_handle (purple_notify_get_handle ());
+    remove (SIGNALD_TMP_QRFILE);
+
+    return TRUE;
+}
+
+gboolean
+signald_new_protocol(SignaldAccount *sa, JsonObject *obj)
+{
+    sa->legacy_protocol = FALSE;
+
+    return TRUE;
+}
+
+gboolean
+signald_old_protocol(SignaldAccount *sa, JsonObject *obj)
+{
+    JsonObject *data = json_object_get_object_member(obj, "data");
+    JsonObject *request = json_object_get_object_member(data, "request");
+    const char *type = json_object_get_string_member(request, "type");
+
+    if (purple_strequal(type, "get_user")) {
+        sa->legacy_protocol = TRUE;
+
+        return TRUE;
+    } else {
+        return FALSE;
+    }
+}
+
+gboolean
+signald_received_contact_list(SignaldAccount *sa, JsonObject *obj)
+{
+    signald_parse_contact_list(sa, json_object_get_array_member(obj, "data"));
+
+    return TRUE;
+}
+
+gboolean
+signald_get_groups(SignaldAccount *sa, JsonObject *obj)
+{
+    signald_request_group_list(sa);
+
+    return TRUE;
+}
+
+gboolean
+signald_received_group_list(SignaldAccount *sa, JsonObject *obj)
+{
+    obj = json_object_get_object_member(obj, "data");
+    signald_parse_group_list(sa, json_object_get_array_member(obj, "groups"));
+
+    return TRUE;
+}
+
+gboolean
+signald_received_message(SignaldAccount *sa, JsonObject *obj)
+{
+    SignaldMessage msg;
+
+    if (signald_parse_message(sa, json_object_get_object_member(obj, "data"), &msg)) {
+        switch(msg.type) {
+            case SIGNALD_MESSAGE_TYPE_DIRECT:
+                signald_process_direct_message(sa, &msg);
+                break;
+
+            case SIGNALD_MESSAGE_TYPE_GROUP:
+                signald_process_group_message(sa, &msg);
+                break;
+        }
+    }
+
+    return TRUE;
+}
+
+gboolean
+signald_received_account_list(SignaldAccount *sa, JsonObject *obj)
+{
+    JsonObject *data = json_object_get_object_member(obj, "data");
+
+    signald_parse_account_list(sa, json_object_get_array_member(data, "accounts"));
+
+    return TRUE;
+}
+
+void
+signald_init_state_machine()
+{
+    if (entrypoint != NULL) {
+        current = entrypoint;
+        return;
+    }
+
+    SignaldState *version;
+    SignaldState *subscribed, *linking, *linked;
+    SignaldState *user, *user_not_registered, *unexpected_error;
+    SignaldState *contacts;
+    SignaldState *running;
+
+    /*
+     * Initialization portion of the state machine.
+     *
+     * From "start" we can get the version and then go to linking or subscribing.
+     *
+     * At the end of both paths we end up in "subscribed".
+     */
+    entrypoint = signald_new_state(NULL, "start", NULL, NULL, NULL);
+
+    version = signald_new_state(entrypoint, "got version, waiting", "version", signald_received_version, NULL);
+
+    /*
+     * Easy case, already subscribed.  Just get the message and move on to
+     * checking the protocol version.
+     */
+    subscribed = signald_new_state(version, "subscribe successful, check protocol", "subscribed", signald_subscribed, signald_check_proto_version);
+
+    /*
+     * The fun case.  Request the linking URI, wait for success (or error),
+     * then if successful, subscribe.
+     */
+    linking = signald_new_state(version, "got linking uri, waiting", "linking_uri", signald_linking_uri, NULL);
+    linked = signald_new_state(linking, "linking successful, subscribing", "linking_successful", signald_linking_successful, signald_subscribe_after_link);
+    signald_add_transition(linked, "subscribed", subscribed, signald_subscribed, signald_check_proto_version);
+
+    signald_new_state(linking, "error linking", "linking_error", signald_linking_error, NULL);
+
+    /*
+     * Alright, we're subscribed and we've initiated messaging to check the
+     * protocol version.
+     *
+     * What we get back determines the protocol version, and then we request
+     * the contact list.
+     */
+    // If we get a user back, we have the new protocol
+    user = signald_new_state(subscribed, "new protocol detected, get contacts", "user", signald_new_protocol, signald_initialize_contacts);
+    // If we get no user back, we have the new protocol
+    user_not_registered = signald_new_state(subscribed, "new protocol detected, get contacts", "user_not_registered", signald_new_protocol, signald_initialize_contacts);
+    // If we get an error, we have the old protocol
+    unexpected_error = signald_new_state(subscribed, "old protocol detected, get contacts", "unexpected_error", signald_old_protocol, signald_initialize_contacts);
+
+    /*
+     * Once the contact list comes back, we request the group list.
+     */
+    contacts = signald_new_state(user, "got contacts, get groups", "contact_list", signald_received_contact_list, signald_get_groups);
+    signald_add_transition(user_not_registered, "get_contacts", contacts, signald_received_contact_list, signald_get_groups);
+    signald_add_transition(unexpected_error, "get_contacts", contacts, signald_received_contact_list, signald_get_groups);
+
+    /*
+     * Group list has arrived, transition to running state.
+     */
+    running = signald_new_state(contacts, "running", "group_list", signald_received_group_list, NULL);
+
+    /*
+     * Normal even loop.  We transition from "running" back to "running", with
+     * various for the message types.
+     */
+    signald_add_transition(running, "message", running, signald_received_message, NULL);
+    signald_add_transition(running, "group_created", running, signald_get_groups, NULL);
+    signald_add_transition(running, "group_updated", running, signald_get_groups, NULL);
+    signald_add_transition(running, "group_list", running, signald_received_group_list, NULL);
+    signald_add_transition(running, "account_list", running, signald_received_account_list, NULL);
+
+    current = entrypoint;
+}
+
+gboolean
+signald_handle_message(SignaldAccount *sa, JsonObject *obj)
+{
+    const gchar *type = json_object_get_string_member(obj, "type");
+    SignaldStateTransition *transition = g_hash_table_lookup(current->transitions, type);
+
+    purple_debug_info(SIGNALD_PLUGIN_ID,
+                       "Initializing: In state '%s' received message type '%s'\n", 
+                       current->name,
+                       type);
+
+    if (transition == NULL) {
+        return FALSE;
+    }
+
+    if ((transition->handler != NULL) && ! transition->handler(sa, obj)) {
+        return FALSE;
+    }
+
+    purple_debug_info(SIGNALD_PLUGIN_ID,
+                      "Initializing: Transitioned from '%s' to '%s'\n", 
+                      current->name,
+                      transition->next->name);
+
+    if ((transition->next_message != NULL) && ! transition->next_message(sa, obj)) {
+        return FALSE;
+    }
+
+    current = transition->next;
+
+    if (g_hash_table_size(current->transitions) == 0) {
+        sa->initialized = TRUE;
+
+        purple_debug_info(SIGNALD_PLUGIN_ID, "Initializing: Initialization complete!\n");
+    }
+
+    return TRUE;
+}

--- a/state.c
+++ b/state.c
@@ -326,12 +326,14 @@ signald_handle_message(SignaldAccount *sa, JsonObject *obj)
                       transition->next->name);
 
     if ((transition->next_message != NULL) && ! transition->next_message(sa, obj)) {
-        purple_debug_info(SIGNALD_PLUGIN_ID, "Reached terminal state in state machine.\n");
-
         return FALSE;
     }
 
     current = transition->next;
+
+    if (current == NULL) {
+        purple_debug_info(SIGNALD_PLUGIN_ID, "Reached terminal state in state machine.\n");
+    }
 
     return TRUE;
 }

--- a/state.h
+++ b/state.h
@@ -1,0 +1,25 @@
+#ifndef __SIGNALD_INIT_H__
+#define __SIGNALD_INIT_H__
+
+typedef gboolean (*SignaldTransitionCb)(SignaldAccount *, JsonObject *obj);
+
+typedef struct {
+    char *name;
+
+    GHashTable *transitions;
+} SignaldState;
+
+typedef struct {
+    SignaldTransitionCb handler;
+    SignaldTransitionCb next_message;
+
+    SignaldState *next;
+} SignaldStateTransition;
+
+void
+signald_init_state_machine();
+
+gboolean
+signald_handle_message(SignaldAccount *sa, JsonObject *obj);
+
+#endif

--- a/state.h
+++ b/state.h
@@ -1,21 +1,6 @@
 #ifndef __SIGNALD_INIT_H__
 #define __SIGNALD_INIT_H__
 
-typedef gboolean (*SignaldTransitionCb)(SignaldAccount *, JsonObject *obj);
-
-typedef struct {
-    char *name;
-
-    GHashTable *transitions;
-} SignaldState;
-
-typedef struct {
-    SignaldTransitionCb handler;
-    SignaldTransitionCb next_message;
-
-    SignaldState *next;
-} SignaldStateTransition;
-
 void
 signald_init_state_machine();
 


### PR DESCRIPTION
So... this is... a pretty major further re-plumbing and I'd totally understand if you might not want to accept this. :)

The primary message loop is already pretty complicated.  There's an implicit state machine that's built into it that's just sort've threaded through the code.

This is fine for now, but as I'm looking at the signald upgrade, I'm a bit concerned that it might need to get even more complex.  It looks like there may be a need to call `sync_groups` and `sync_contacts` during initialization, and so we have even more steps.

So this refactoring formalizes the message handling into an actual state machine.

The state machine is constructed of nodes, each of which has a name and a hash of state transitions that can occur from that node.

The transition carries with it:

- A callback to invoke upon receipt of a message.
- A separate callback to invoke to trigger the next event (if applicable).  e.g. contact_list -> list_groups
- The next state.

The callbacks are split to allow for reuse.

The main event loop is then facilitated with state transitions from `running` to `running` for each of the message types that are supported.

Anyway, let me know what you think.  This is a significant change, but I'm thinking we might want the flexibility in the future, and I like how it "unwinds" the main loop and makes the state machine explicit.

As you can see, this basically guts most of signald_handle_input, so libsignald.c is even shorter now.

And as a bonus, the debug logging is a lot more useful since the transitions are explicit and logged.

I've tested linking, regular startup, and some basic messaging activities and it all seems to work nicely.

Feedback is welcome!