### PR TITLE
Groups v2

### DIFF
--- a/groups.c
+++ b/groups.c
@@ -182,13 +182,22 @@ signald_add_group(SignaldAccount *sa, const char *groupId, const char *groupName
 
     group->id = g_str_hash(groupId);
     group->name = g_strdup(groupName);
-    group->chat = NULL;
     group->conversation = NULL;
     group->users = NULL;
 
     signald_update_group_user_list(sa, group, members, NULL, NULL);
 
-    // TODO: Find the chat in our buddy list and if it's not there, add it.
+    group->chat = purple_blist_find_chat(sa->account, group->name);
+
+    if (group->chat == NULL) {
+        GHashTable *comp = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+
+        g_hash_table_insert(comp, g_strdup("name"), g_strdup(group->name));
+        group->chat = purple_chat_new(sa->account, group->name, comp);
+
+        purple_blist_add_chat(group->chat, NULL, NULL);
+        purple_blist_node_set_bool((PurpleBlistNode *)group->chat, "gtk-persistent", TRUE);
+    }
 
     g_hash_table_insert(sa->groups, g_strdup(groupId), group);
 }

--- a/groups.c
+++ b/groups.c
@@ -334,11 +334,9 @@ signald_update_group(SignaldAccount *sa, const char *groupId, const char *groupN
         signald_add_group(sa, groupId, groupName, members);
 
         // Now open the conversation window/channel/whatever.
-        //
-        // TODO: Only open the conversation if our settings say always open
-        // *or* if we're *not* currently initializing (indicating we were
-        // invited while this session was active).
-        signald_open_conversation(sa, groupId);
+        if (purple_account_get_bool(sa->account, "auto-join-group-chats", FALSE)) {
+            signald_open_conversation(sa, groupId);
+        }
 
         return;
     } else if ((group != NULL) && ! in_group) {
@@ -456,10 +454,7 @@ signald_process_group_message(SignaldAccount *sa, SignaldMessage *msg)
             // In this case, we know about the conversation but it's not been
             // opened yet so there's no place to write the message.
 
-            // TODO: Open the conversation and continue if our settings
-            // indicate we should.
-            //
-            // signald_open_conversation(sa, groupid_str);
+            signald_open_conversation(sa, groupid_str);
             return;
         }
 

--- a/groups.c
+++ b/groups.c
@@ -455,7 +455,6 @@ signald_process_group_message(SignaldAccount *sa, SignaldMessage *msg)
             // opened yet so there's no place to write the message.
 
             signald_open_conversation(sa, groupid_str);
-            return;
         }
 
         if (signald_format_message(sa, msg, &content, &has_attachment)) {

--- a/groups.c
+++ b/groups.c
@@ -234,10 +234,8 @@ signald_quit_group(SignaldAccount *sa, const char *groupId)
         return;
     }
 
-    int id = group->id;
-
     if (group->conversation != NULL) {
-        serv_got_chat_left(sa->pc, id);
+        serv_got_chat_left(sa->pc, group->id);
     }
 
     g_free(group->name);
@@ -294,9 +292,11 @@ signald_update_group(SignaldAccount *sa, const char *groupId, const char *groupN
 
     signald_update_group_user_list(sa, group, members, &added, &removed);
 
-    purple_conv_chat_remove_users(PURPLE_CONV_CHAT(group->conversation), removed, NULL);
+    if (group->conversation != NULL) {
+        purple_conv_chat_remove_users(PURPLE_CONV_CHAT(group->conversation), removed, NULL);
 
-    signald_add_users_to_conv(group, added);
+        signald_add_users_to_conv(group, added);
+    }
 
     g_list_free_full(added, g_free);
     g_list_free_full(removed, g_free);

--- a/groups.c
+++ b/groups.c
@@ -326,7 +326,13 @@ signald_update_group(SignaldAccount *sa, const char *groupId, const char *groupN
     gboolean in_group = signald_members_contains(sa, members, username);
 
     if ((group == NULL) && (! in_group)) {
-        // Chat that we neither know about nor we're in?  Ignore it.
+        // Chat that we neither know about nor we're in.
+        // Let's see if we had an old buddy list entry we should delete.
+        PurpleChat *chat = signald_blist_find_chat(sa, groupId);
+
+        if (chat != NULL) {
+            purple_blist_remove_chat(chat);
+        }
 
         return;
     } else if ((group == NULL) && in_group) {

--- a/groups.c
+++ b/groups.c
@@ -293,9 +293,13 @@ signald_update_group(SignaldAccount *sa, const char *groupId, const char *groupN
     signald_update_group_user_list(sa, group, members, &added, &removed);
 
     if (group->conversation != NULL) {
-        purple_conv_chat_remove_users(PURPLE_CONV_CHAT(group->conversation), removed, NULL);
+        if (removed != NULL) {
+            purple_conv_chat_remove_users(PURPLE_CONV_CHAT(group->conversation), removed, NULL);
+        }
 
-        signald_add_users_to_conv(group, added);
+        if (added != NULL) {
+            signald_add_users_to_conv(group, added);
+        }
     }
 
     g_list_free_full(added, g_free);

--- a/groups.c
+++ b/groups.c
@@ -236,15 +236,15 @@ signald_quit_group(SignaldAccount *sa, const char *groupId)
 
     int id = group->id;
 
+    if (group->conversation != NULL) {
+        serv_got_chat_left(sa->pc, id);
+    }
+
     g_free(group->name);
     g_list_free_full(group->users, g_free);
 
     // This will free the key and the group automatically.
     g_hash_table_remove(sa->groups, groupId);
-
-    if (group->conversation != NULL) {
-        serv_got_chat_left(sa->pc, id);
-    }
 
     // TODO: Find the chat in our buddy list and if it's there, remove it.
 }

--- a/groups.c
+++ b/groups.c
@@ -657,8 +657,7 @@ GHashTable
 void
 signald_set_chat_topic(PurpleConnection *pc, int id, const char *topic)
 {
-    SignaldAccount *sa = purple_connection_get_protocol_data(pc);
-    gchar *groupId = signald_find_groupid_for_conv_id(sa, id);
-
-    printf("Changing %s topic to %s\n", groupId, topic);
+    // Nothing to do here.  For some reason this callback has to be
+    // registered if Pidgin is going to enable the "Alias..." menu
+    // option in the conversation.
 }

--- a/groups.h
+++ b/groups.h
@@ -2,7 +2,6 @@
 #define __SIGNALD_GROUPS_H__
 
 #define SIGNALD_CONV_GROUPID_KEY "signalGroupId"
-#define SIGNALD_CONV_GROUPNAME_KEY "signalGroupName"
 
 // Instances of this object are stored in SignaldAccount.  The IDs are
 // Signal group IDs that are used as keys in a hash table where these
@@ -50,9 +49,15 @@ void
 signald_chat_leave(PurpleConnection *pc, int id);
 
 void
+signald_chat_rename(PurpleConnection *pc, PurpleChat *chat);
+
+void
 signald_chat_invite(PurpleConnection *pc, int id, const char *message, const char *who);
 
 int
 signald_send_chat(PurpleConnection *pc, int id, const char *message, PurpleMessageFlags flags);
+
+void
+signald_set_chat_topic(PurpleConnection *pc, int id, const char *topic);
 
 #endif

--- a/groups.h
+++ b/groups.h
@@ -4,6 +4,26 @@
 #define SIGNALD_CONV_GROUPID_KEY "signalGroupId"
 #define SIGNALD_CONV_GROUPNAME_KEY "signalGroupName"
 
+// Instances of this object are stored in SignaldAccount.  The IDs are
+// Signal group IDs that are used as keys in a hash table where these
+// entries are stored.
+typedef struct {
+    // Pidgin chat ID we'll be using.
+    int id;
+
+    // The user-friendly name from this group.
+    char *name;
+
+    // The buddy list entry that represents this signal group.
+    PurpleChat *chat;
+
+    // The active conversation for this entry.
+    PurpleConversation *conversation;
+
+    // The list of users in this group.
+    GList *users;
+} SignaldGroup;
+
 void
 signald_parse_group_list(SignaldAccount *sa, JsonArray *groups);
 

--- a/libsignald.c
+++ b/libsignald.c
@@ -578,6 +578,13 @@ signald_add_account_options(GList *account_options)
                 );
     account_options = g_list_append(account_options, option);
 
+    option = purple_account_option_bool_new(
+                _("Automatically join group chats on startup"),
+                "auto-join-group-chats",
+                FALSE
+                );
+    account_options = g_list_append(account_options, option);
+
 #ifdef SUPPORT_EXTERNAL_ATTACHMENTS
 
     option = purple_account_option_bool_new(

--- a/libsignald.c
+++ b/libsignald.c
@@ -450,7 +450,7 @@ signald_login(PurpleAccount *account)
     sa->watcher = purple_input_add(fd, PURPLE_INPUT_READ, signald_read_cb, sa);
 
     // Initialize the container where we'll store our group mappings
-    sa->groups = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
+    sa->groups = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 
     if (! purple_account_get_bool(sa->account, "handle_signald", FALSE)) {
         // subscribe if signald is globally running


### PR DESCRIPTION
This PR represents a refactoring that culminates in control over whether groups are automatically opened/joined at startup.

First, we refactoring all the tracking so that groups are stored alongside the SignaldAccount in their own list.  Previously group data was attached to the conversation, but since we may not have open conversations for all groups right away, we have to start tracking that information separately.

Second, we automatically add group chats to the buddy list and mark them persistent.  Since we're not automatically opening chats, this is the only way to ensure the user has a way to open a group chat that isn't opened yet.  Marking them persistent ensures that when you close the chat, you don't accidentally leave it unless you really mean it!

Third, since we're in here adding a bunch of capabilities anyway, we add support for renaming group chats.  We do this using the Pidgin "Alias..." function, such that if you alias a chat it's renamed in the Signal protocol and all the associated tracking is updated.  Similarly, if we receive a rename, we automatically alias the chat to rename it.

Then, last but not least, we add the new auto-join-group-chats setting.  When disabled, group chats are only automatically opened when a message is received (this ensures we don't lose any messages; if we didn't open the conversation, we'd have nowhere to put them!)  When enabled, they're opened at startup as per the previous behaviour.

The default is to *not* automatically open chats.  So Bitlbee users will definitely want to enable this setting.