### PR TITLE
Basic quoted message support.

### DIFF
--- a/message.c
+++ b/message.c
@@ -231,6 +231,18 @@ signald_format_message(SignaldAccount *sa, SignaldMessage *msg, GString **target
         *has_attachment = FALSE;
     }
 
+    if (json_object_has_member(msg->data, "quote")) {
+        JsonObject *quote = json_object_get_object_member(msg->data, "quote");
+        const char *text = json_object_get_string_member(quote, "text");
+        gchar **lines = g_strsplit(text, "\n", 0);
+
+        for (int i = 0; lines[i] != NULL; i++) {
+            g_string_append_printf(*target, "> %s\n", lines[i]);
+        }
+
+        g_strfreev(lines);
+    }
+
     // append actual message text
     g_string_append(*target, json_object_get_string_member(msg->data, SIGNALD_BODY_FIELD(sa)));
 


### PR DESCRIPTION
Take out the quoted text, split it by newlines, prepend each line with
"> " to indicate it's a quote, then emit it, followed by a newline and
the reply text.

This looks good in Bitlbee and just okay in Pidgin.  I'm starting to
wonder if multi-line messages should be split and emitted in Pidgin,
generally, but for now this is in keeping with how these types of
messages are formatted today.

Note, this PR does not do anything with quoted attachments at this time.