### PR TITLE
Fix NPE on messages for a groups we're not in.

### DIFF
--- a/groups.c
+++ b/groups.c
@@ -451,6 +451,13 @@ signald_process_group_message(SignaldAccount *sa, SignaldMessage *msg)
         PurpleMessageFlags flags = 0;
         SignaldGroup *group = (SignaldGroup *)g_hash_table_lookup(sa->groups, groupid_str);
 
+        if (group == NULL) {
+            // This seems to happen when clients aren't fully in sync on the
+            // group membership...
+
+            return;
+        }
+
         gboolean has_attachment = FALSE;
         GString *content = NULL;
 


### PR DESCRIPTION
Yes, this can happen.  Signal groups are basically a shared consensus.
Each client has their own idea of the group membership, and hopefully
everyone agrees.

If not, sometimes you can get a message for a group you already left.
Weird.

We just ignore these.  It's better than crashing!