### PR TITLE
Remove legacy protocol support

### DIFF
--- a/contacts.c
+++ b/contacts.c
@@ -55,15 +55,8 @@ signald_process_contact(JsonArray *array, guint index_, JsonNode *element_node, 
     SignaldAccount *sa = (SignaldAccount *)user_data;
     JsonObject *obj = json_node_get_object(element_node);
     const char *alias = json_object_get_string_member(obj, "name");
-    const char *username = NULL;
-
-    if (sa->legacy_protocol) {
-      username = json_object_get_string_member(obj, "number");
-    } else {
-      JsonObject *address = json_object_get_object_member(obj, "address");
-
-      username = json_object_get_string_member(address, "number");
-    }
+    JsonObject *address = json_object_get_object_member(obj, "address");
+    const char *username = json_object_get_string_member(address, "number");
 
     signald_add_purple_buddy(sa, username, alias);
 }

--- a/groups.c
+++ b/groups.c
@@ -76,12 +76,8 @@ signald_find_groupid_for_conv_name(SignaldAccount *sa, gchar *name)
 char *
 signald_get_group_member_name(SignaldAccount *sa, JsonNode *node)
 {
-    if (sa->legacy_protocol) {
-        return (char *)json_node_get_string(node);
-    } else {
-        JsonObject *member = json_node_get_object(node);
-        return (char *)json_object_get_string_member(member, "number");
-    }
+    JsonObject *member = json_node_get_object(node);
+    return (char *)json_object_get_string_member(member, "number");
 }
 
 /*
@@ -423,7 +419,7 @@ signald_request_group_list(SignaldAccount *sa)
 void
 signald_process_group_message(SignaldAccount *sa, SignaldMessage *msg)
 {
-    JsonObject *groupInfo = json_object_get_object_member(msg->data, SIGNALD_GROUP_FIELD(sa));
+    JsonObject *groupInfo = json_object_get_object_member(msg->data, "group");
 
     const gchar *type = json_object_get_string_member(groupInfo, "type");
     const gchar *groupid_str = json_object_get_string_member(groupInfo, "groupId");

--- a/libsignald.h
+++ b/libsignald.h
@@ -60,7 +60,6 @@ typedef struct {
     PurpleConnection *pc;
 
     gboolean initialized;
-    gboolean legacy_protocol;
 
     int fd;
     guint watcher;

--- a/message.c
+++ b/message.c
@@ -195,28 +195,18 @@ signald_get_number_from_field(SignaldAccount *sa, JsonObject *obj, const char *f
     }
 
     JsonNode *node = json_object_get_member(obj, field);
+    JsonObject *address = json_node_get_object(node);
 
-    if (sa->legacy_protocol) {
-        return json_node_get_string(node);
-    } else {
-        // Dealing with a JsonAddress instance
-        JsonObject *address = json_node_get_object(node);
-
-        return (const char *)json_object_get_string_member(address, "number");
-    }
+    return (const char *)json_object_get_string_member(address, "number");
 }
 
 void
 signald_set_recipient(SignaldAccount *sa, JsonObject *obj, gchar *recipient)
 {
-    if (sa->legacy_protocol) {
-        json_object_set_string_member(obj, "recipientNumber", recipient);
-    } else {
-        JsonObject *address = json_object_new();
+    JsonObject *address = json_object_new();
 
-        json_object_set_string_member(address, "number", recipient);
-        json_object_set_string_member(obj, "recipientAddress", recipient);
-    }
+    json_object_set_string_member(address, "number", recipient);
+    json_object_set_string_member(obj, "recipientAddress", recipient);
 }
 
 gboolean
@@ -244,7 +234,7 @@ signald_format_message(SignaldAccount *sa, SignaldMessage *msg, GString **target
     }
 
     // append actual message text
-    g_string_append(*target, json_object_get_string_member(msg->data, SIGNALD_BODY_FIELD(sa)));
+    g_string_append(*target, json_object_get_string_member(msg->data, "body"));
 
     return (*target)->len > 0; // message not empty
 }
@@ -288,7 +278,7 @@ signald_parse_message(SignaldAccount *sa, JsonObject *obj, SignaldMessage *msg)
         msg->conversation_name = SIGNALD_UNKNOWN_SOURCE_NUMBER;
     }
 
-    if (json_object_has_member(msg->data, SIGNALD_GROUP_FIELD(sa))) {
+    if (json_object_has_member(msg->data, "group")) {
         msg->type = SIGNALD_MESSAGE_TYPE_GROUP;
     } else {
         msg->type = SIGNALD_MESSAGE_TYPE_DIRECT;

--- a/message.h
+++ b/message.h
@@ -1,9 +1,6 @@
 #ifndef __SIGNALD_MESSAGE_H__
 #define __SIGNALD_MESSAGE_H__
 
-#define SIGNALD_BODY_FIELD(sa) ((sa->legacy_protocol == TRUE) ? "message" : "body")
-#define SIGNALD_GROUP_FIELD(sa) ((sa->legacy_protocol == TRUE) ? "groupInfo" : "group")
-
 typedef enum {
     SIGNALD_MESSAGE_TYPE_DIRECT = 1,
     SIGNALD_MESSAGE_TYPE_GROUP = 2


### PR DESCRIPTION
Both signald and its clients should be updated regularly to stay compatible with Signal itself, so there is no need to support legacy protocols for more than a short transition period. This is also recommended by the [signald author](https://gitlab.com/signald/signald/-/issues/99#note_484229508).

Also, in this case, it seems libpurple-signald can be confused into using the legacy protocol even with a recent signald, causing the communcation to fail and losing messages.