### PR TITLE
More updates for Bitblee configuration by demure

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ Once that is successful, in the `&root` channel of Bitlbee, add the same phone n
 ```
 account add hehoe-signald +12223334444
 rename _12223334444 name-sig
-account hehoe-signald on
+account hehoe-signald set tag signal
+account signal set auto-join-group-chats true
+account signal set nick_format %full_name-sig
+account signal on
 ```
 To create a channel for Signal, auto join it and generally manage your contacts see - https://wiki.bitlbee.org/ManagingContactList
 


### PR DESCRIPTION
Some more configurations users should set when creating an account in Bitlbee to make using Signal easier.
Thanks to @demure - http://up.demu.red/pb/2021-01-21_8e9d5673.txt

Rename account to make the name less annoying
acc hehoe-signald set tag signal

Autojoin groups
acc signal set auto-join-group-chats true

Show the contact name instead of phone number. the '-sig' is a string, so I can tell which Protocol
acc signal set nick_format %full_name-sig