### PR TITLE
updated syncing contacts and groups due to changes in signal

### DIFF
--- a/groups.c
+++ b/groups.c
@@ -527,23 +527,9 @@ signald_request_group_list(SignaldAccount *sa)
 {
     JsonObject *data = json_object_new();
 
-    json_object_set_string_member(data, "type", "sync_groups");
-    json_object_set_string_member(data, "username", purple_account_get_username(sa->account));
-
-    if (!signald_send_json(sa, data)) {
-        purple_connection_error(sa->pc, PURPLE_CONNECTION_ERROR_NETWORK_ERROR, _("Could not request contacts."));
-    }
-
-    json_object_unref(data);
-}
-
-void
-signald_get_group_list(SignaldAccount *sa)
-{
-    JsonObject *data = json_object_new();
-
     json_object_set_string_member(data, "type", "list_groups");
     json_object_set_string_member(data, "username", purple_account_get_username(sa->account));
+    json_object_set_string_member(data, "version", "v0");
 
     if (!signald_send_json(sa, data)) {
         purple_connection_error(sa->pc, PURPLE_CONNECTION_ERROR_NETWORK_ERROR, _("Could not request contacts."));

--- a/groups.h
+++ b/groups.h
@@ -33,9 +33,6 @@ void
 signald_request_group_list(SignaldAccount *sa);
 
 void
-signald_get_group_list(SignaldAccount *sa);
-
-void
 signald_process_group_message(SignaldAccount *sa, SignaldMessage *msg);
 
 void

--- a/libsignald.h
+++ b/libsignald.h
@@ -67,7 +67,6 @@ typedef struct {
 
     gboolean account_exists; // whether account exists in signald
     gboolean groups_updated; // whether groups have been updated after login
-    gboolean got_contacts; // whether contacts have been pulled
 
     int fd;
     guint watcher;


### PR DESCRIPTION
The requests `sync_contacts` and `sync_groups` (v0) lead to errors after recent changes in the main branch of signal. This commit replaces them by the v1 request `request_sync`.
