### PR TITLE
Request and handle groupV2 info on unknown groupV2 message

### DIFF
--- a/libsignald.c
+++ b/libsignald.c
@@ -187,6 +187,11 @@ signald_handle_input(SignaldAccount *sa, const char * json)
         } else if (purple_strequal(type, "request_sync")) {
             signald_list_contacts(sa);
 
+        } else if (purple_strequal(type, "get_group")) {
+            obj = json_object_get_object_member(obj, "data");
+            signald_process_groupV2_obj(sa, obj);
+            sa->groups_updated = TRUE;
+
         } else if (purple_strequal(type, "group_list")) {
             obj = json_object_get_object_member(obj, "data");
             signald_parse_group_list(sa, json_object_get_array_member(obj, "groups"));


### PR DESCRIPTION
With the death of list_groups (91c33dd), this provides a workaround in that an incoming message will trigger its group's creation if necessary.

N.B. that initial incoming message will get lost though.

( @thefinn93 list_groups throws NPE, even using signaldctl? )