### PR TITLE
Pull request

### DIFF
--- a/groups.c
+++ b/groups.c
@@ -462,7 +462,6 @@ signald_request_group_info(SignaldAccount *sa, const char *groupid_str)
 
     json_object_set_string_member(data, "type", "get_group");
     json_object_set_string_member(data, "account", sa->uuid);
-    json_object_set_string_member(data, "version", "v1");
     json_object_set_string_member(data, "groupID", groupid_str);
 
     if (!signald_send_json(sa, data)) {
@@ -481,7 +480,6 @@ signald_request_group_list(SignaldAccount *sa)
 
     json_object_set_string_member(data, "type", "list_groups");
     json_object_set_string_member(data, "account", sa->uuid);
-    json_object_set_string_member(data, "version", "v1");
 
     if (!signald_send_json(sa, data)) {
         purple_connection_error(sa->pc, PURPLE_CONNECTION_ERROR_NETWORK_ERROR, _("Could not request groups."));

--- a/groups.c
+++ b/groups.c
@@ -338,7 +338,7 @@ signald_accept_groupV2_invitation(SignaldAccount *sa, const char *groupId, JsonA
         // we are a pending member, join it
         JsonObject *message = json_object_new();
         json_object_set_string_member(message, "type", "accept_invitation");
-        json_object_set_string_member(message, "account", purple_account_get_username(sa->account));
+        json_object_set_string_member(message, "account", sa->uuid);
         json_object_set_string_member(message, "groupID", groupId);
         if (!signald_send_json(sa, message)) {
             purple_connection_error(sa->pc, PURPLE_CONNECTION_ERROR_NETWORK_ERROR, _("Could not send message for accepting group invitation."));
@@ -461,7 +461,7 @@ signald_request_group_info(SignaldAccount *sa, const char *groupid_str)
     JsonObject *data = json_object_new();
 
     json_object_set_string_member(data, "type", "get_group");
-    json_object_set_string_member(data, "account", purple_account_get_username(sa->account));
+    json_object_set_string_member(data, "account", sa->uuid);
     json_object_set_string_member(data, "version", "v1");
     json_object_set_string_member(data, "groupID", groupid_str);
 
@@ -480,7 +480,7 @@ signald_request_group_list(SignaldAccount *sa)
     JsonObject *data = json_object_new();
 
     json_object_set_string_member(data, "type", "list_groups");
-    json_object_set_string_member(data, "account", purple_account_get_username(sa->account));
+    json_object_set_string_member(data, "account", sa->uuid);
     json_object_set_string_member(data, "version", "v1");
 
     if (!signald_send_json(sa, data)) {

--- a/groups.c
+++ b/groups.c
@@ -435,6 +435,10 @@ signald_process_groupV2_obj(SignaldAccount *sa, JsonObject *obj)
         json_object_get_string_member(obj, "avatar"),
         json_object_get_array_member(obj, "members")
     );
+
+    purple_debug_info (SIGNALD_PLUGIN_ID, "Processing group ID %s, %s\n",
+                       json_object_get_string_member(obj, "id"),
+                       json_object_get_string_member(obj, "title"));
 }
 
 void

--- a/libsignald.c
+++ b/libsignald.c
@@ -82,6 +82,7 @@ signald_subscribe (SignaldAccount *sa)
     JsonObject *data = json_object_new();
 
     json_object_set_string_member(data, "type", "subscribe");
+    // FIXME: subscribe with uuid as "account" does not work (account not found)
     json_object_set_string_member(data, "account", purple_account_get_username(sa->account));
 
     if (!signald_send_json (sa, data)) {
@@ -97,7 +98,7 @@ signald_request_sync(SignaldAccount *sa)
     JsonObject *data = json_object_new();
 
     json_object_set_string_member(data, "type", "request_sync");
-    json_object_set_string_member(data, "account", purple_account_get_username(sa->account));
+    json_object_set_string_member(data, "account", sa->uuid);
     json_object_set_boolean_member(data, "contacts", TRUE);
     json_object_set_boolean_member(data, "groups", TRUE);
     json_object_set_boolean_member(data, "configuration", FALSE);
@@ -116,7 +117,7 @@ signald_list_contacts(SignaldAccount *sa)
     JsonObject *data = json_object_new();
 
     json_object_set_string_member(data, "type", "list_contacts");
-    json_object_set_string_member(data, "account", purple_account_get_username(sa->account));
+    json_object_set_string_member(data, "account", sa->uuid);
     // TODO: v1
 
     if (!signald_send_json (sa, data)) {


### PR DESCRIPTION
Since `request_sync` followed by `list_contacts` as well as `list_groups` are working again as expected, the first commit re-enables those requests at startup.

The other commits 

- change the number to the UUID as `account` field in most requests (for `subscribe` this does not seem to work, although the UUID is used for the `account` in [the documentation ](https://signald.org/protocol/actions/v1/subscribe/)),
- implement a test for the member `error` in incoming json message stuctures, and
- remove setting `version` to `v1` for individual requests as this is globally done in `signald_send_json` already.